### PR TITLE
Bugfixes and chunked_demo integration

### DIFF
--- a/src/backend_stub/logic.js
+++ b/src/backend_stub/logic.js
@@ -292,7 +292,7 @@ module.exports = function (config) {
 			};
 			
 			return {
-				value0: layout
+				layout: layout
 			};
 		},
 		
@@ -300,7 +300,7 @@ module.exports = function (config) {
 			var metaId = params.meta_id;
 			
 			return {
-				value0: meta[metaId]
+				meta: meta[metaId]
 			};
 		},
 		
@@ -315,11 +315,10 @@ module.exports = function (config) {
 			var reader = new Reader(_store, seriesId, since, function (data) {
 				logger.info(streamLogPrefix + 'Reading ' + data.length + ' samples.');
 				
-				writeFn({
-					value0: {
-						data: data
-					}
-				});
+				// Send one top-level JSON object per data sample:
+				for (var ic = data.length, i = 0; i < ic; ++i) {
+					writeFn(data[i]);
+				}
 			});
 			
 			reader.start();

--- a/src/backend_stub/logic.js
+++ b/src/backend_stub/logic.js
@@ -18,7 +18,7 @@ Store.prototype.getDataSince = function (seriesId, since) {
 	var _this = this,
 		updatesData = [],
 		storeData = _this.getData(seriesId),
-		ic = storeData.length,
+		ic = (storeData ? storeData.length : 0),
 		i = ic-1;
 	
 	while (i >= 0) {
@@ -32,22 +32,22 @@ Store.prototype.getDataSince = function (seriesId, since) {
 	return updatesData;
 };
 Store.prototype.addSeries = function (seriesId, options) {
-	var seriesData = this._data[seriesId] = this._data[seriesId] || [];
+	this._data[seriesId] = this._data[seriesId] || [];
 	this._options[seriesId] = _.extend({}, options);
 };
 Store.prototype.addData = function (seriesId, updateData) {
 	var seriesData = this._data[seriesId];
 	
-	if (updateData && updateData.length) {
+	if (seriesData && updateData && updateData.length) {
 		seriesData.push.apply(seriesData, updateData);
 	}
 };
 Store.prototype.collectData = function (seriesId) {
 	var seriesData = this._data[seriesId];
+	var options = this._options[seriesId];
 	
-	var collectFn = this._options[seriesId].collectFn;
-	
-	if (seriesData && collectFn) {
+	if (seriesData && options && options.collectFn) {
+		var collectFn = options.collectFn;
 		collectFn(function (value) {
 			var now = Date.now();
 			
@@ -177,8 +177,9 @@ module.exports = function (config) {
 		return config.httpBaseUrl + '/meta?meta_id=' + metaId;
 	}
 	
-	function makeDataUrl(seriesId) {
-		return config.httpBaseUrl + '/data?series_id=' + seriesId;
+	function makeDataUrl(metaId, seriesId) {
+		// WARNING: The frontend assumes unique data URLs, so we include metaId.
+		return config.httpBaseUrl + '/data?meta_id=' + metaId + '&series_id=' + seriesId;
 	}
 	
 	function makeLayoutCell(metaId) {
@@ -191,7 +192,7 @@ module.exports = function (config) {
 	
 	var meta = {
 		"1": {
-			data_url: makeDataUrl('cpu'),
+			data_url: makeDataUrl('1', 'cpu'),
 			visualizer_name: 'plot-visualizer',
 			visualizer_options: {
 				header_text: 'CPU Load',
@@ -202,7 +203,7 @@ module.exports = function (config) {
 			}
 		},
 		"2": {
-			data_url: makeDataUrl('memory'),
+			data_url: makeDataUrl('2', 'memory'),
 			visualizer_name: 'plot-visualizer',
 			visualizer_options: {
 				header_text: 'Memory Footprint',
@@ -212,7 +213,7 @@ module.exports = function (config) {
 			}
 		},
 		"3": {
-			data_url: makeDataUrl('cpu'),
+			data_url: makeDataUrl('3', 'cpu'),
 			visualizer_name: 'plot-visualizer',
 			visualizer_options: {
 				header_text: 'CPU Load copy',
@@ -223,7 +224,7 @@ module.exports = function (config) {
 			}
 		},
 		"4": {
-			data_url: makeDataUrl('cpu'),
+			data_url: makeDataUrl('4', 'cpu'),
 			visualizer_name: 'value-visualizer',
 			visualizer_options: {
 				header_text: 'CPU Load Value',
@@ -237,7 +238,7 @@ module.exports = function (config) {
 	(function () {
 		for (var ic = TEST_DATA_SERIES_COUNT, i = 0; i < ic; ++i) {
 			meta['data' + i] = {
-				data_url: makeDataUrl('data' + i),
+				data_url: makeDataUrl('data' + i, 'data' + i),
 				visualizer_name: 'plot-visualizer',
 				visualizer_options: {
 					header_text: 'Data ' + i,

--- a/src/frontend/dashboard-data-store.js
+++ b/src/frontend/dashboard-data-store.js
@@ -67,9 +67,11 @@ _.extend(DashboardDataStore.prototype, {
 	
 	_handleMeta: function (args) {
 		var _this = this,
-			dataUrl = args.meta.data_url,
 			meta = args.meta,
+			dataUrl = meta.data_url,
 			timeInterval = (meta.visualizer_options && meta.visualizer_options.time_interval);
+		
+		// WARNING: The frontend assumes unique data URLs.
 		
 		// Update the meta cache:
 		_this._meta[dataUrl] = meta;
@@ -86,6 +88,8 @@ _.extend(DashboardDataStore.prototype, {
 			data = args.data,
 			meta = _this._meta[dataUrl],
 			timeInterval = (meta.visualizer_options && meta.visualizer_options.time_interval);
+		
+		// WARNING: The frontend assumes unique data URLs.
 		
 		// Create the data array if required:
 		var seriesData = _this._data[dataUrl] = _this._data[dataUrl] || [];

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -122,7 +122,10 @@ function init() {
 					// to the latest data sample time (add 1 to avoid duplicates):
 					queryParams.since = data.x + 1;
 					persistentConnection.setUrl(
-						queryStringUtil.extend(persistentConnection.getUrl(), queryParams)
+						queryStringUtil.extend(
+							persistentConnection.getUrl(),
+							queryParams
+						)
 					);
 					
 					// Notify that the data has been received:

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -4,8 +4,9 @@ var $ = require('jquery');
 var _ = require('underscore');
 var EventEmitter = require('node-event-emitter');
 
+var queryStringUtil = require('./query-string-util');
+
 var PersistentConnection = require('./persistent-connection');
-var ChunkParser = require('./chunk-parser');
 var JsonPerLineParser = require('./json-per-line-parser');
 
 var Dashboard = require('./dashboard');
@@ -120,7 +121,9 @@ function init() {
 					// Advance the time that will go in the next request
 					// to the latest data sample time (add 1 to avoid duplicates):
 					queryParams.since = data.x + 1;
-					persistentConnection.setQuery(queryParams);
+					persistentConnection.setUrl(
+						queryStringUtil.extend(persistentConnection.getUrl(), queryParams)
+					);
 					
 					// Notify that the data has been received:
 					dispatcher.emit('receive-data', {

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -40,7 +40,7 @@ function init() {
 				url: this.normalizeUrl(layoutUrl),
 				dataType: 'json'
 			}).then(function (response) {
-				var layout = response.value0;
+				var layout = response.layout;
 			
 				if (layout) {
 					logger.log(logPrefix + 'Loaded layout from ' + layoutUrl + ':', layout);
@@ -62,7 +62,7 @@ function init() {
 				url: this.normalizeUrl(metaUrl),
 				dataType: 'json'
 			}).then(function (response) {
-				var meta = response.value0;
+				var meta = response.meta;
 				
 				if (meta) {
 					logger.log(logPrefix + 'Loaded meta from ' + metaUrl + ':', meta);
@@ -96,10 +96,6 @@ function init() {
 				logPrefix: 	logPrefix + ' [' + dataUrl + '] [PersistentConnection] '
 			});
 			
-			var chunkParser = new ChunkParser({
-				logPrefix: 	logPrefix + ' [' + dataUrl + '] [ChunkParser] '
-			});
-			
 			var jsonPerLineParser = new JsonPerLineParser({
 				logPrefix: 	logPrefix + ' [' + dataUrl + '] [JsonPerLineParser] '
 			});
@@ -111,34 +107,25 @@ function init() {
 			}
 			
 			persistentConnection.on('connected', function (data) {
-				chunkParser.reset();
 				jsonPerLineParser.reset();
 			});
 			persistentConnection.on('data', function (data) {
-				chunkParser.write(data);
+				jsonPerLineParser.write(data);
 			});
 			persistentConnection.on('end', reconnectOnError);
 			persistentConnection.on('error', reconnectOnError);
 			
-			chunkParser.on('data', function (data) {
-				jsonPerLineParser.write(data);
-			});
-			chunkParser.on('end', reconnectOnError);
-			chunkParser.on('error', reconnectOnError);
-			
 			jsonPerLineParser.on('data', function (data) {
-				data = (data && data.value0 && data.value0.data);
-				
-				if (data && data.length > 0) {
+				if (data && typeof data.x === 'number' && typeof data.y === 'number') {
 					// Advance the time that will go in the next request
 					// to the latest data sample time (add 1 to avoid duplicates):
-					queryParams.since = data[data.length-1].x + 1;
+					queryParams.since = data.x + 1;
 					persistentConnection.setQuery(queryParams);
 					
 					// Notify that the data has been received:
 					dispatcher.emit('receive-data', {
 						dataUrl: dataUrl,
-						data: data
+						data: [ data ]
 					});
 				}
 			});

--- a/src/frontend/json-per-line-parser.js
+++ b/src/frontend/json-per-line-parser.js
@@ -66,7 +66,7 @@ _.extend(JsonPerLineParser.prototype, {
 	},
 	
 	_onData: function (jsonObject) {
-		logger.log(this._options.logPrefix + 'Data:', jsonObject);
+		//logger.log(this._options.logPrefix + 'Data:', jsonObject);
 		this.emit('data', jsonObject);
 	},
 	

--- a/src/frontend/persistent-connection.js
+++ b/src/frontend/persistent-connection.js
@@ -33,7 +33,7 @@ function PersistentConnection(options) {
 		reconnectDelayCoeff: 1.1
 	}, options);
 	
-	_this._queryParams = {};
+	_this._url = null;
 	
 	_this.disconnect();
 }
@@ -58,17 +58,14 @@ _.extend(PersistentConnection.prototype, {
 	 * Opens a persistent connection on a given URL.
 	 * The server is expected to keep the connection open forever and push the data.
 	 *
-	 * @param {string} url The URL to request.
-	 * @param {Object.<string,string>} [queryParams={}] The query parameters to add to the URL. May be updated later via `setQuery`.
+	 * @param {string} url The URL to request. May be updated later via `setUrl`.
 	 */
-	connect: function (url, queryParams) {
+	connect: function (url) {
 		var _this = this;
 		
 		_this._dropConnection();
 		
 		_this._url = url;
-		
-		_this.setQuery(queryParams);
 		
 		_this._resetReconnectParams();
 		
@@ -76,10 +73,17 @@ _.extend(PersistentConnection.prototype, {
 	},
 	
 	/**
-	 * Updates the query parameters for future reconnects.
+	 * Returns the URL.
 	 */
-	setQuery: function (queryParams) {
-		this._queryParams = _.extend({}, queryParams);
+	getUrl: function () {
+		return this._url;
+	},
+	
+	/**
+	 * Updates the URL for future reconnects.
+	 */
+	setUrl: function (url) {
+		this._url = url;
 	},
 	
 	/**
@@ -88,6 +92,10 @@ _.extend(PersistentConnection.prototype, {
 	 */
 	reconnect: function () {
 		var _this = this;
+		
+		if (!_this._url) {
+			throw new Error('PersistentConnection#reconnect: Missing URL.');
+		}
 		
 		_this._dropConnection();
 		
@@ -212,11 +220,7 @@ _.extend(PersistentConnection.prototype, {
 			}
 		};
 		
-		var requestUrl = _this._url;
-		requestUrl += (requestUrl.indexOf('?') < 0 ? '?' : '&');
-		requestUrl += $.param(_this._queryParams);
-		
-		xhr.open('GET', requestUrl, true);
+		xhr.open('GET', _this._url, true);
 		
 		xhr.send(null);
 	},

--- a/src/frontend/persistent-connection.js
+++ b/src/frontend/persistent-connection.js
@@ -151,7 +151,7 @@ _.extend(PersistentConnection.prototype, {
 	},
 	
 	_onData: function (data) {
-		logger.log(this._options.logPrefix + 'Data:', data);
+		//logger.log(this._options.logPrefix + 'Data:', data);
 		this.emit('data', data);
 	},
 	

--- a/src/frontend/query-string-util.js
+++ b/src/frontend/query-string-util.js
@@ -1,8 +1,31 @@
 'use strict';
 
+// Note: Not using more full-fledged query string modules because they are rather large.
+
 var $ = require('jquery');
 
-var parse = function (queryString) {
+
+/**
+ * Borrowed from `qs` module.
+ * @see https://github.com/hapijs/qs/blob/master/lib/utils.js#L68
+ */
+function decode(str) {
+	try {
+		return decodeURIComponent(str.replace(/\+/g, ' '));
+	}
+	catch (err) {
+		return str;
+	}
+}
+
+/**
+ * Parses the query string in a simplest way.
+ * Only supports non-nested query strings with non-repeating keys.
+ *
+ * @param {string} queryString The query string.
+ * @return {Object} The query params.
+ */
+function parse(queryString) {
 	var params = {}, pairs, pair, i, ic;
 
 	// Split into key/value pairs:
@@ -11,23 +34,37 @@ var parse = function (queryString) {
 	// Convert the array of strings into an object:
 	for (i = 0, ic = pairs.length; i < ic; i++) {
 		pair = pairs[i].split('=');
-		params[pair[0]] = pair[1];
+		params[decode(pair[0])] = decode(pair[1] || '');
 	}
 
 	return params;
-};
+}
 
-var stringify = function (params) {
+/**
+ * Re-uses `jQuery.param` for building query strings.
+ *
+ * @param {Object} params The query params.
+ * @return {string} The query string.
+ */
+function stringify(params) {
 	return $.param(params || {});
-};
+}
 
-var extend = function (url, params) {
+/**
+ * Extends the query string of an existing URL.
+ *
+ * @param {string} url The initial URL.
+ * @param {Object} params The params that need ot be updated.
+ * @return {string} The updated URL.
+ */
+function extend(url, params) {
 	var index = url.indexOf('?');
 	var beforeQueryString = (index < 0 ? url : url.substring(0, index));
 	var queryString = (index < 0 ? '' : url.substring(index + 1));
-	url = beforeQueryString + '?' + stringify($.extend(true, parse(queryString), params));
+	url = beforeQueryString + '?' + stringify($.extend(parse(queryString), params));
 	return url;
-};
+}
+
 
 module.exports = {
 	parse: parse,

--- a/src/frontend/query-string-util.js
+++ b/src/frontend/query-string-util.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var $ = require('jquery');
+
+var parse = function (queryString) {
+	var params = {}, pairs, pair, i, ic;
+
+	// Split into key/value pairs:
+	pairs = queryString.split('&');
+
+	// Convert the array of strings into an object:
+	for (i = 0, ic = pairs.length; i < ic; i++) {
+		pair = pairs[i].split('=');
+		params[pair[0]] = pair[1];
+	}
+
+	return params;
+};
+
+var stringify = function (params) {
+	return $.param(params || {});
+};
+
+var extend = function (url, params) {
+	var index = url.indexOf('?');
+	var beforeQueryString = (index < 0 ? url : url.substring(0, index));
+	var queryString = (index < 0 ? '' : url.substring(index + 1));
+	url = beforeQueryString + '?' + stringify($.extend(true, parse(queryString), params));
+	return url;
+};
+
+module.exports = {
+	parse: parse,
+	stringify: stringify,
+	extend: extend
+};


### PR DESCRIPTION
* Fixed writing chunked data CRLF (it got replaced with just LF
somewhere internally). This resulted in the browser understanding the
chunked stream and decoding it, so the `chunk-parser` has become
useless.
* Changed response root object names from "value0" to "layout" and
"meta".
* Changed sending data samples to one data sample per send (this is how
the data is sent from the `chunked_demo`).
* Commented out data logging (performance drops).