### PR TITLE
Cerealize-friendly /config.json and underscores

### DIFF
--- a/src/backend_stub/index.js
+++ b/src/backend_stub/index.js
@@ -72,22 +72,29 @@ module.exports = {
 		
 		// Provide the config from the backend:
 		app.get('/config.json', cors(), function (req, res) {
+			var frontendConfig = {
+				layout_url: '/layout',
+				data_hostnames: config.dataHostnames
+			};
 			var responseJson = {
-				dataHostnames: config.dataHostnames,
-				layoutUrl: '/layout'
+				config: frontendConfig
 			};
 			logger.info('Config requested. Response: ' + JSON.stringify(responseJson));
 			res.json(responseJson);
 		});
 		
 		app.get('/layout', cors(), function (req, res) {
-			var responseJson = logic.getLayout();
+			var responseJson = {
+				layout: logic.getLayout()
+			};
 			logger.info('Layout requested. Response: ' + JSON.stringify(responseJson));
 			res.json(responseJson);
 		});
 		
 		app.get('/layout/meta', cors(), function (req, res) {
-			var responseJson = logic.getMeta(req.query);
+			var responseJson = {
+				meta: logic.getMeta(req.query)
+			};
 			logger.info('Meta ' + JSON.stringify(req.query) + ' requested. Response: ' + JSON.stringify(responseJson));
 			res.json(responseJson);
 		});

--- a/src/backend_stub/logic.js
+++ b/src/backend_stub/logic.js
@@ -331,17 +331,13 @@ module.exports = function (config) {
 				]
 			};
 			
-			return {
-				layout: layout
-			};
+			return layout;
 		},
 		
 		getMeta: function (params) {
 			var metaId = params.meta_id;
 			
-			return {
-				meta: meta[metaId]
-			};
+			return meta[metaId];
 		},
 		
 		streamData: function (params, writeFn, options) {

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -48,9 +48,9 @@ function init() {
 				dataType: 'json'
 			}).then(function (response) {
 				config = _.extend({
-					layoutUrl: '/layout',
-					dataHostnames: []
-				}, response);
+					layout_url: '/layout',
+					data_hostnames: []
+				}, response && response.config);
 				
 				backendApi.loadLayout();
 			}, function (jqXHR) {
@@ -64,7 +64,7 @@ function init() {
 		 * Loads the layout via the URL from the config.
 		 */
 		loadLayout: function () {
-			var layoutUrl = config.layoutUrl;
+			var layoutUrl = config.layout_url;
 			
 			$.ajax({
 				url: layoutUrl,
@@ -91,7 +91,7 @@ function init() {
 		 * Loads the metadata for a single layout cell.
 		 */
 		loadMeta: function (metaUrl) {
-			var metaUrlFull = config.layoutUrl + metaUrl;
+			var metaUrlFull = config.layout_url + metaUrl;
 			
 			$.ajax({
 				url: metaUrlFull,
@@ -175,11 +175,11 @@ function init() {
 			});
 			jsonPerLineParser.on('error', reconnectOnError);
 			
-			var dataUrlFull = config.layoutUrl + dataUrl;
+			var dataUrlFull = config.layout_url + dataUrl;
 			
 			// Use the next hostname from the config, if available.
 			var dataUrlParsed = URL.parse(dataUrlFull);
-			var dataHostnames = config.dataHostnames;
+			var dataHostnames = config.data_hostnames;
 			if (
 				dataHostnames && dataHostnames.length > 0
 				&& (dataUrlParsed.hostname === 'localhost' || (


### PR DESCRIPTION
* Renamed the /config.json fields to use underscores.
* Changed /config.json response to use a top-level object with a
"config" property to make the structure cerealize-friendly.
* Moved the top-level objects from the backend_stub logic to the server
which builds the responses.