### PR TITLE
Added support for serving from a subdirectory

### DIFF
--- a/src/backend_stub/config.js
+++ b/src/backend_stub/config.js
@@ -5,17 +5,21 @@ var webpackConfig = require('../../webpack.config.js');
 /**
  * backend_stub configuration.
  * 
- * "dataHostnames" is an array of domain names that resolve to the backend server.
- * This array is put into the frontend config that is returned from the backend.
- * The hostnames are then used by the frontend to fool the browser's connection limit.
- * For the frontend to work with this backend_stub configuration, these hostnames
- * should be added to /etc/hosts.
- * The production backend should reply with a list of publicly resolvable hostnames.
+ * @property {string} baseUrl Base URL for all the entry points.
+ *     Given "/" serves "/", "/static/*", "/config.json", "/layout" etc.
+ *     Given "/test/" serves "/test", "/test/", "/test/static/*", "/test/config.json", "/test/layout" etc.
+ * 
+ * @property {Array.<string>} dataHostnames An array of domain names that resolve to the backend server.
+ *     This array is put into the frontend config that is returned from the backend.
+ *     The hostnames are then used by the frontend to fool the browser's connection limit.
+ *     For the frontend to work with this backend_stub configuration, these hostnames
+ *     should be added to /etc/hosts.
+ *     The production backend should reply with a list of publicly resolvable hostnames.
  */
 module.exports = {
 	httpPort: 3001,
-	staticBaseUrl: webpackConfig.output.publicPath,
 	staticPath: webpackConfig.output.path,
+	baseUrl: '/',
 	dataHostnames: [
 		'd0.knowsheet.local',
 		'd1.knowsheet.local',

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -40,23 +40,30 @@ function init() {
 		 * that resolve to the backend to fool the browser's domain connection limit.
 		 */
 		loadConfig: function () {
-			// Load the config from the backend:
-			var configUrl = '/config.json';
+			// Load the config from the backend.
+			// The backend should guarantee `pathname` to have a trailing slash.
+			var baseUrl = window.location.pathname;
+			var configUrl = baseUrl + 'config.json';
 			
 			$.ajax({
 				url: configUrl,
 				dataType: 'json'
 			}).then(function (response) {
 				config = _.extend({
-					layout_url: '/layout',
+					layout_url: null,
 					data_hostnames: []
 				}, response && response.config);
+				
+				if (!config.layout_url) {
+					logger.error(logPrefix + 'Empty "layout_url" in config from ' + configUrl + ':', config);
+					window.alert('Got invalid config from ' + configUrl + '.');
+					return;
+				}
 				
 				backendApi.loadLayout();
 			}, function (jqXHR) {
 				logger.error(logPrefix + 'Failed to load config from ' + configUrl + ':', jqXHR);
-				
-				global.alert('An error occurred while loading config from ' + configUrl + '.');
+				window.alert('An error occurred while loading config from ' + configUrl + '.');
 			});
 		},
 		
@@ -82,8 +89,7 @@ function init() {
 				}
 			}, function (jqXHR) {
 				logger.error(logPrefix + 'Failed to load layout from ' + layoutUrl + ':', jqXHR);
-				
-				global.alert('An error occurred while loading layout from ' + layoutUrl + '.');
+				window.alert('An error occurred while loading layout from ' + layoutUrl + '.');
 			});
 		},
 		
@@ -109,8 +115,7 @@ function init() {
 				}
 			}, function (jqXHR) {
 				logger.error(logPrefix + 'Failed to load meta from ' + metaUrlFull + ':', jqXHR);
-				
-				global.alert('An error occurred while loading meta from ' + metaUrlFull + '.');
+				window.alert('An error occurred while loading meta from ' + metaUrlFull + '.');
 			});
 		},
 		

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -35,8 +35,8 @@ function init() {
 	var backendApi = {
 		/**
 		 * Loads the config from the backend, then loads the layout.
-		 * The config includes "layoutUrl" which is the base for other URLs.
-		 * The config includes "dataHostnames" which is an array of hostnames 
+		 * The config includes "layout_url" which is the base for other URLs.
+		 * The config includes "data_hostnames" which is an array of hostnames 
 		 * that resolve to the backend to fool the browser's domain connection limit.
 		 */
 		loadConfig: function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ var webpackConfig = {
 	context: __dirname,
 	output: {
 		path: path.join(__dirname, (isProduction ? "build" : "build-dev")),
-		publicPath: "/static/",
+		// Use a relative `publicPath` to be able to serve from a subdirectory.
+		publicPath: "static/",
 		filename: "[name].js?[chunkhash]"
 	},
 	entry: {


### PR DESCRIPTION
* frontend: Use relative URLs to static files in the `index.html`
(generated from webpack `publicPath`).
* frontend: Use config URL relative to the URL from which the frontend
entry page is served.
* frontend: Changed `global.alert` to `window.alert` (though `alert` is
a bad habit).
* backend_stub: Added `baseUrl` config option. Serve all the entry
points at URLs prefixed with the `baseUrl`. Respond with `layout_url`
prefixed with the `baseUrl` (the `meta_url` and `data_url` are already
relative to the `layout_url`).