### PR TITLE
Added support for dashboard HTML template

### DIFF
--- a/src/backend_stub/dashboard-template.html
+++ b/src/backend_stub/dashboard-template.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
 	<meta charset="utf-8"/>
 	<title>KnowSheet Demo</title>
-	<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,300,600&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">
+	<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,300,600&amp;subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">
 	<style>
 		.knsh-sticky-footer {
 			-webkit-box-sizing: border-box;

--- a/src/backend_stub/dashboard-template.html
+++ b/src/backend_stub/dashboard-template.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+	<meta charset="utf-8"/>
+	<title>KnowSheet Demo</title>
+	<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,300,600&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">
+	<style>
+		.knsh-sticky-footer {
+			-webkit-box-sizing: border-box;
+			-moz-box-sizing: border-box;
+			box-sizing: border-box;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+			height: 100%;
+		}
+		.knsh-sticky-footer__frame {
+			-webkit-box-sizing: border-box;
+			-moz-box-sizing: border-box;
+			box-sizing: border-box;
+			display: table;
+			table-layout: fixed;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+			height: 100%;
+		}
+		.knsh-sticky-footer__row {
+			display: table-row;
+			height: 1px;
+		}
+		.knsh-sticky-footer__row.knsh-sticky-footer__row__m-expand {
+			height: auto;
+		}
+		
+		
+		.knsh-columns {
+			-webkit-box-sizing: border-box;
+			-moz-box-sizing: border-box;
+			box-sizing: border-box;
+			display: table;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+		}
+		.knsh-columns__item {
+			display: table-cell;
+		}
+		
+		
+		.knsh-body {
+			margin: 0;
+			padding: 0;
+			
+			position: relative;
+			
+			background: #eee;
+			
+			font: 14px 'Open Sans', Arial, sans-serif;
+		}
+		
+		.knsh-theme .knsh-header {
+			padding: 10px 30px 18px;
+			background: #D84315;
+			color: #FFFFFF;
+		}
+		.knsh-theme .knsh-header a {
+			color: #EEEEEE;
+		}
+		.knsh-theme .knsh-header a:hover,
+		.knsh-theme .knsh-header a:focus,
+		.knsh-theme .knsh-header a:active {
+			color: #FFFFFF;
+		}
+		
+		.knsh-theme .knsh-header-logo {
+		}
+		.knsh-theme .knsh-header-logo__link {
+			display: inline-block;
+			text-decoration: none;
+			color: #FFFFFF;
+		}
+		.knsh-theme .knsh-header-logo__image {
+			font-size: 30px;
+			white-space: nowrap;
+		}
+		.knsh-theme .knsh-header-logo__alpha {
+			font-size: 14px;
+			margin-left: 2px;
+			position: relative;
+			top: -4px;
+		}
+		.knsh-theme .knsh-header-logo__caption {
+			font-size: 14px;
+			white-space: nowrap;
+		}
+		
+		.knsh-theme .knsh-footer {
+			padding: 20px 30px 20px;
+			background: #212121;
+			color: #E0E0E0;
+		}
+		.knsh-theme .knsh-footer a {
+			color: #EEEEEE;
+		}
+		.knsh-theme .knsh-footer a:hover,
+		.knsh-theme .knsh-footer a:focus,
+		.knsh-theme .knsh-footer a:active {
+			color: #FFFFFF;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout {
+			padding: 20px;
+			
+			background: #FFFFFF;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout-card {
+			border: 1px solid #FFFFFF;
+			
+			background: #FFFFFF;
+			
+			-webkit-box-shadow: 0 0 0 0 rgba(0,0,0,0);
+			box-shadow: 0 0 0 0 rgba(0,0,0,0);
+			
+			-webkit-transform: scale(1);
+			-moz-transform: scale(1);
+			-ms-transform: scale(1);
+			transform: scale(1);
+			
+			-webkit-transition: all 0.3s ease-in;
+			-moz-transition: all 0.3s ease-in;
+			-ms-transition: all 0.3s ease-in;
+			-o-transition: all 0.3s ease-in;
+			transition: all 0.3s ease-in;
+			
+			-webkit-transition-delay: 0s;
+			-moz-transition-delay: 0s;
+			-ms-transition-delay: 0s;
+			-o-transition-delay: 0s;
+			transition-delay: 0s;
+			
+			-webkit-border-radius: 0px;
+			border-radius: 0px;
+		}
+		.knsh-theme .knsh-dashboard-layout-card:hover {
+			z-index: 1;
+			
+			border-color: #E2E2E2;
+			
+			-webkit-transform: scale(1.03);
+			-moz-transform: scale(1.03);
+			-ms-transform: scale(1.03);
+			transform: scale(1.03);
+			
+			-webkit-box-shadow: 0 0 80px -10px rgba(0,0,0,0.5);
+			box-shadow: 0 0 80px -10px rgba(0,0,0,0.5);
+			
+			-webkit-border-radius: 2px;
+			border-radius: 2px;
+			
+			-webkit-transition-delay: 0.3s;
+			-moz-transition-delay: 0.3s;
+			-ms-transition-delay: 0.3s;
+			-o-transition-delay: 0.3s;
+			transition-delay: 0.3s;
+		}
+		
+		.knsh-theme .knsh-image-visualizer__wrapper {
+			min-height: 200px;
+		}
+	</style>
+</head>
+<body class="knsh-body knsh-sticky-footer knsh-theme">
+	<div class="knsh-sticky-footer__frame">
+		<div class="knsh-sticky-footer__row">
+			<div class="knsh-header-wrapper">
+				<header class="knsh-header">
+					<div class="knsh-columns">
+						<div class="knsh-columns__item">
+							<div class="knsh-header-logo">
+								<a href="/" class="knsh-header-logo__link"><span class="knsh-header-logo__image">KnowSheet<sup class="knsh-header-logo__alpha" title="Alpha">&alpha;lpha</sup></span></a>
+								<div class="knsh-header-logo__caption">The real-time data insights made easy.</div>
+							</div>
+						</div>
+						<div class="knsh-columns__item" style="text-align: right;">
+							<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+						</div>
+					</div>
+				</header>
+			</div>
+		</div>
+		<div class="knsh-sticky-footer__row knsh-sticky-footer__row__m-expand">
+			<div class="knsh-dashboard-root"></div>
+		</div>
+		<div class="knsh-sticky-footer__row">
+			<div class="knsh-footer-wrapper">
+				<footer class="knsh-footer">
+					<div class="knsh-columns">
+						<div class="knsh-columns__item">
+							<div class="knsh-footer-copyright">&copy; 2015 The KnowSheet Team</div>
+						</div>
+						<div class="knsh-columns__item" style="text-align: right;">
+							<div class="knsh-footer-links">
+								<div class="knsh-footer-links__item">
+									<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</footer>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/src/backend_stub/index.js
+++ b/src/backend_stub/index.js
@@ -82,12 +82,23 @@ module.exports = {
 		});
 		// DEBUG */
 		
-		// Provide the config from the backend:
+		// Provide the frontend config from the backend.
 		app.get(config.baseUrl + 'config.json', cors(), function (req, res) {
+			// Read the dashboard template from the file.
+			// TODO(sompylasar): Build templates from HTML and LESS instead of the single HTML+CSS file.
+			// TODO(sompylasar): Personalized templates (?).
+			var dashboardTemplateHtml = require('fs').readFileSync(__dirname + '/dashboard-template.html', {
+				encoding: 'utf8'
+			});
+			
+			// Compose the frontend configuration object.
 			var frontendConfig = {
 				layout_url: config.baseUrl + 'layout',
-				data_hostnames: config.dataHostnames
+				data_hostnames: config.dataHostnames,
+				dashboard_template: dashboardTemplateHtml
 			};
+			
+			// Respond with the configuration.
 			var responseJson = {
 				config: frontendConfig
 			};

--- a/src/frontend/dashboard-layout.less
+++ b/src/frontend/dashboard-layout.less
@@ -54,15 +54,9 @@
 .knsh-dashboard-layout-card {
 	.box-sizing(border-box);
 	
-	margin: 10px;
+	margin: 0;
 	padding: 0;
+	border: 0 none;
 	
 	width: 100%;
-	
-	background: #fff;
-	border: 1px solid #d8d8d8;
-	border-bottom-width: 2px;
-	border-top-width: 0;
-	
-	.border-radius(3px);
 }

--- a/src/frontend/index.blueimp.html
+++ b/src/frontend/index.blueimp.html
@@ -2,10 +2,11 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-	<meta charset="utf-8"/>	
+	<meta charset="utf-8"/>
 	<script src="{%=o.htmlWebpackPlugin.assets.vendor%}"></script>
 </head>
 <body>
+	<div class="knsh-dashboard-root"></div>
 	<script src="{%=o.htmlWebpackPlugin.assets.app%}"></script>
 </body>
 </html>

--- a/src/frontend/index.less
+++ b/src/frontend/index.less
@@ -1,15 +1,8 @@
 @import "~prefixer.less";
 @import "~flexbox.less";
 
-.knsh-root {
-	.box-sizing(border-box);
-	
+html, body {
 	margin: 0;
 	padding: 0;
-	
-	position: relative;
-	
-	background: #eee;
-	
-	font: 14px Arial;
+	height: 100%;
 }

--- a/src/frontend/visualizers/image-visualizer.less
+++ b/src/frontend/visualizers/image-visualizer.less
@@ -31,8 +31,7 @@
 	}
 	
 	&__image {
-		width: 100%;
-		height: auto;
+		max-width: 100%;
 		border: 0 none;
 	}
 	

--- a/src/frontend/visualizers/plot-visualizer.less
+++ b/src/frontend/visualizers/plot-visualizer.less
@@ -19,7 +19,7 @@
 		
 		min-height: 100px;
 		
-		padding: 4px;
+		padding: 10px;
 	}
 	
 	&__plot {


### PR DESCRIPTION
* backend_stub: Added `dashboard_template` config option. Added a
sample dashboard template.
* frontend: Use the `dashboard_template` obtained from the backend
config as a dashboard template.

![2015-02-20 7 07 54](https://cloud.githubusercontent.com/assets/498274/6281296/6300c2a2-b8cf-11e4-8f32-6124f90aa389.png)
