### PR TITLE
Made CSS classes for layout elements customizable

### DIFF
--- a/src/backend_stub/dashboard-template.html
+++ b/src/backend_stub/dashboard-template.html
@@ -118,9 +118,11 @@
 		
 		.knsh-theme .knsh-dashboard-layout-card {
 			border: 1px solid #FFFFFF;
-			
 			background: #FFFFFF;
-			
+			color: #000000;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout-card.knsh-theme-popout {
 			-webkit-box-shadow: 0 0 0 0 rgba(0,0,0,0);
 			box-shadow: 0 0 0 0 rgba(0,0,0,0);
 			
@@ -144,10 +146,13 @@
 			-webkit-border-radius: 0px;
 			border-radius: 0px;
 		}
-		.knsh-theme .knsh-dashboard-layout-card:hover {
+		
+		.knsh-theme .knsh-dashboard-layout-card.knsh-theme-popout:hover {
 			z-index: 1;
 			
-			border-color: #E2E2E2;
+			border-color: #EDEDED;
+			background: #FFFFFF;
+			color: #000000;
 			
 			-webkit-transform: scale(1.03);
 			-moz-transform: scale(1.03);
@@ -165,6 +170,28 @@
 			-ms-transition-delay: 0.3s;
 			-o-transition-delay: 0.3s;
 			transition-delay: 0.3s;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout-group.knsh-theme-accented .knsh-dashboard-layout-card {
+			border-color: #263238;
+			background: #263238;
+			color: #FFFFFF;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout-card.knsh-theme-accented,
+		.knsh-theme .knsh-dashboard-layout-card.knsh-theme-accented:hover {
+			border-color: #263238;
+			background: #263238;
+			color: #FFFFFF;
+		}
+		
+		.knsh-theme .knsh-dashboard-layout-group.knsh-theme-accented .knsh-dashboard-layout-card .knsh-value-visualizer__figure,
+		.knsh-theme .knsh-dashboard-layout-card.knsh-theme-accented .knsh-value-visualizer__figure {
+			text-shadow: 
+				1px 0px 0px #FFFFFF,
+				-1px 0px 0px #FFFFFF,
+				0px 1px 0px #FFFFFF,
+				0px -1px 0px #FFFFFF;
 		}
 		
 		.knsh-theme .knsh-image-visualizer__wrapper {

--- a/src/backend_stub/logic.js
+++ b/src/backend_stub/logic.js
@@ -245,9 +245,13 @@ module.exports = function (config) {
 		return '/data?meta_id=' + metaId + '&series_id=' + seriesId;
 	}
 	
-	function makeLayoutCell(metaId) {
+	function makeLayoutCell(metaId, options) {
 		return {
 			cell: {
+				css_classes: {
+					'knsh-theme-popout': options && options.isPopout,
+					'knsh-theme-accented': options && options.isAccented
+				},
 				meta_url: makeMetaUrl(metaId)
 			}
 		};
@@ -313,6 +317,7 @@ module.exports = function (config) {
 				data_url: makeDataUrl('data' + i, 'data' + i),
 				visualizer_name: 'plot-visualizer',
 				visualizer_options: {
+					css_classes: 'knsh-theme-accented',
 					header_text: 'Data ' + i,
 					color: 'blue',
 					min: 0.0,
@@ -329,6 +334,7 @@ module.exports = function (config) {
 				col: [
 					// --- Basic layout ---
 					{
+						css_classes: 'knsh-theme-accented',
 						row: [
 							makeLayoutCell('1'),
 							makeLayoutCell('2'),
@@ -342,18 +348,31 @@ module.exports = function (config) {
 					// The same data stream:
 					{
 						row: [
-							makeLayoutCell('data0'),
-							makeLayoutCell('data0'),
-							makeLayoutCell('data0'),
-							makeLayoutCell('data0'),
-							makeLayoutCell('data0')
+							makeLayoutCell('data0', {
+								isPopout: true
+							}),
+							makeLayoutCell('data0', {
+								isPopout: true
+							}),
+							makeLayoutCell('data0', {
+								isPopout: true
+							}),
+							makeLayoutCell('data0', {
+								isPopout: true
+							}),
+							makeLayoutCell('data0', {
+								isPopout: true
+							})
 						]
 					},
 					
 					// Different data streams:
 					{
 						row: [
-							makeLayoutCell('data0'),
+							makeLayoutCell('data0', {
+								isPopout: true,
+								isAccented: true
+							}),
 							makeLayoutCell('data1'),
 							makeLayoutCell('data2'),
 							makeLayoutCell('data3'),

--- a/src/frontend/dashboard-layout.js
+++ b/src/frontend/dashboard-layout.js
@@ -80,7 +80,8 @@ _.extend(DashboardLayout.prototype, {
 		
 		_this._traverseLayout(_this._layout, {},
 			function (ctx, layout) {
-				var $layout = layout.$layout = $('<div class="knsh-dashboard-layout-group"></div>');
+				var $layout = layout.$layout = $('<div class="knsh-dashboard-layout-group ' +
+					require('./util-css-classes')(layout.css_classes) + '"></div>');
 				
 				if (layout.row) {
 					$layout.addClass('knsh-dashboard-layout-group__m-row');
@@ -100,7 +101,8 @@ _.extend(DashboardLayout.prototype, {
 				$item.appendTo(layout.$items);
 				
 				if (cell) {
-					var $card = cell.$card = $('<div class="knsh-dashboard-layout-card"></div>');
+					var $card = cell.$card = $('<div class="knsh-dashboard-layout-card ' +
+						require('./util-css-classes')(cell.css_classes) + '"></div>');
 					
 					$card.appendTo($item);
 				}

--- a/src/frontend/util-css-classes.js
+++ b/src/frontend/util-css-classes.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var $ = require('jquery');
+
+/**
+ * Converts an array, object to a string intended to be used as CSS classes.
+ * 
+ * Examples:
+    * ```javascript
+         [ "css-class-1", "css-class-2" ] // -> "css-class-1 css-class-2"
+```
+    * ```javascript
+         "   css-class-1   css-class-2  " // -> "css-class-1 css-class-2"
+```
+    * ```javascript
+         {
+             "css-class-1": true,
+             "css-class-2": true,
+             "css-class-3": false
+         }
+         // -> "css-class-1 css-class-2"
+```
+ * 
+ * @param {string|Array.<string>|Object.<string,boolean>} 
+ * @return {string}
+ */
+function makeStringFromOptions(cssClasses) {
+	var cssClassesString = '';
+	
+	if ($.isArray(cssClasses)) {
+		// [ "css-class-1", "css-class-2" ]
+		cssClassesString = cssClasses.join(' ');
+	}
+	else if (typeof cssClasses === 'string' || cssClasses instanceof String) {
+		// "css-class-1 css-class-2"
+		cssClassesString = cssClasses;
+	}
+	else if ($.isPlainObject(cssClasses)) {
+		// { "css-class-1": true, "css-class-2": true, "css-class-3": false }
+		$.each(cssClasses, function (k, v) {
+			if (k && v === true) {
+				cssClassesString += ' ' + k;
+			}
+		});
+	}
+	
+	cssClassesString = cssClassesString.replace(/\s+/g, ' ').replace(/(^\s+)|(\s+$)/g, '');
+	
+	return cssClassesString;
+}
+
+module.exports = makeStringFromOptions;

--- a/src/frontend/visualizers/image-visualizer.js
+++ b/src/frontend/visualizers/image-visualizer.js
@@ -48,8 +48,9 @@ function ImageVisualizer(locator, options, dataUrl) {
 	}, options);
 	
 	var blockCssClass = 'knsh-image-visualizer';
+	var additionalCssClasses = ' ' + require('../util-css-classes')(_this._options.css_classes);
 	
-	var $el = _this.$el = $('<div class="' + blockCssClass + '">' +
+	var $el = _this.$el = $('<div class="' + blockCssClass + additionalCssClasses + '">' +
 		'<div class="' + blockCssClass + '__header"></div>' +
 		'<div class="' + blockCssClass + '__wrapper">' +
 			'<div class="' + blockCssClass + '__content">' +

--- a/src/frontend/visualizers/plot-visualizer.js
+++ b/src/frontend/visualizers/plot-visualizer.js
@@ -37,8 +37,9 @@ function PlotVisualizer(locator, options, dataUrl) {
 	_this._plotHeight = 0;
 	
 	var blockCssClass = 'knsh-plot-visualizer';
+	var additionalCssClasses = ' ' + require('../util-css-classes')(_this._options.css_classes);
 	
-	var $el = _this.$el = $('<div class="' + blockCssClass + '">' +
+	var $el = _this.$el = $('<div class="' + blockCssClass + additionalCssClasses + '">' +
 		'<div class="' + blockCssClass + '__header"></div>' +
 		'<div class="' + blockCssClass + '__plot-wrapper">' +
 			'<div class="' + blockCssClass + '__plot"></div>' +

--- a/src/frontend/visualizers/value-visualizer.js
+++ b/src/frontend/visualizers/value-visualizer.js
@@ -22,8 +22,9 @@ function ValueVisualizer(locator, options, dataUrl) {
 	}, options);
 	
 	var blockCssClass = 'knsh-value-visualizer';
+	var additionalCssClasses = ' ' + require('../util-css-classes')(_this._options.css_classes);
 	
-	var $el = _this.$el = $('<div class="' + blockCssClass + '">' +
+	var $el = _this.$el = $('<div class="' + blockCssClass + additionalCssClasses + '">' +
 		'<div class="' + blockCssClass + '__header"></div>' +
 		'<div class="' + blockCssClass + '__wrapper">' +
 			'<div class="' + blockCssClass + '__figure"></div>' +


### PR DESCRIPTION
* frontend: Added support for `css_classes` option in layout groups,
cells and visualizers.
* backend_stub: Added example CSS classes to the `layout` data and to
the `dashboard-template.html`.

This allows customizing some of the display features, e.g. cards popping-out or background color etc..

![2015-02-21 20 20 54](https://cloud.githubusercontent.com/assets/498274/6315067/337e1df2-ba07-11e4-9832-24ae1838281e.png)
