### PR TITLE
Fixes and optimizations for Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "Flot": "flot/flot#v0.8.3",
     "cors": "^2.5.2",
     "css-loader": "^0.9.0",
-    "d3": "^3.4.13",
     "exports-loader": "^0.6.2",
     "express": "^4.10.4",
     "file-loader": "^0.8.1",
@@ -37,7 +37,6 @@
     "moment-timezone": "^0.2.5",
     "node-event-emitter": "0.0.1",
     "openurl": "^1.1.0",
-    "rickshaw": "shutterstock/rickshaw#v1.5.0",
     "script-loader": "^0.6.1",
     "serve-static": "^1.7.1",
     "style-loader": "^0.8.2",

--- a/src/frontend/dashboard-layout.less
+++ b/src/frontend/dashboard-layout.less
@@ -25,28 +25,34 @@
 	
 	&__item {
 		.flexbox();
+		.align-items(stretch);
 		
 		.box-sizing(border-box);
-		
-		width: 100%;
 	}
 	
 	&__m-row {
-		> .knsh-dashboard-layout-group {
-			&__items {
-				.flex-direction(row);
+		> .knsh-dashboard-layout-group__items {
+			.flex-direction(row);
+			.align-items(stretch);
+			
+			@media (max-width: 768px) {
+				.flex-wrap(wrap);
+			}
+			
+			> .knsh-dashboard-layout-group__item {
+				.flex-grow(1);
+				.flex-shrink(0);
+				.flex-basis(0px);
 				
 				@media (max-width: 768px) {
-					.flex-wrap(wrap);
+					.flex-basis(100%);
 				}
 			}
 		}
 	}
 	&__m-col {
-		> .knsh-dashboard-layout-group {
-			&__items {
-				.flex-direction(column);
-			}
+		> .knsh-dashboard-layout-group__items {
+			.flex-direction(column);
 		}
 	}
 }

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -128,6 +128,48 @@ function init() {
 		},
 		
 		/**
+		 * Patches the passed URL with the next hostname from the config, if available.
+		 *
+		 * @param {string} url The URL to patch.
+		 * @return {string} The URL with the hostname replaced, or the initial URL if the hostnames are not available.
+		 */
+		cycleHostname: function (url) {
+			if (!config) {
+				logger.error(logPrefix + 'The config is not loaded.');
+				window.alert('The config is not loaded.');
+				return;
+			}
+			
+			var dataHostnames = config.data_hostnames;
+			
+			// If the hostnames array is not available, the URL is not modified.
+			if (dataHostnames && dataHostnames.length > 0) {
+				// Check and, if required, reset the selected hostname index.
+				if (dataHostnamesRoundRobin >= dataHostnames.length) {
+					dataHostnamesRoundRobin = 0;
+				}
+				
+				// Parse the passed URL into components.
+				var dataUrlParsed = URL.parse(url);
+				
+				// Set the hostname to the selected one.
+				dataUrlParsed.hostname = dataHostnames[dataHostnamesRoundRobin];
+				
+				// Set the protocol and port, they are required if the hostname is set.
+				dataUrlParsed.protocol = dataUrlParsed.protocol || window.location.protocol;
+				dataUrlParsed.port = dataUrlParsed.port || window.location.port;
+				
+				// Combine into a string.
+				url = URL.format(dataUrlParsed);
+				
+				// Advance to the next hostname.
+				dataHostnamesRoundRobin++;
+			}
+			
+			return url;
+		},
+		
+		/**
 		 * Loads the layout via the URL from the config.
 		 * The config must be loaded before.
 		 */
@@ -139,6 +181,8 @@ function init() {
 			}
 			
 			var layoutUrl = config.layout_url;
+			
+			layoutUrl = backendApi.cycleHostname(layoutUrl);
 			
 			$.ajax({
 				url: layoutUrl,
@@ -172,6 +216,8 @@ function init() {
 			}
 			
 			var metaUrlFull = config.layout_url + metaUrl;
+			
+			metaUrlFull = backendApi.cycleHostname(metaUrlFull);
 			
 			$.ajax({
 				url: metaUrlFull,
@@ -268,25 +314,7 @@ function init() {
 			
 			var dataUrlFull = config.layout_url + dataUrl;
 			
-			// Use the next hostname from the config, if available.
-			var dataUrlParsed = URL.parse(dataUrlFull);
-			var dataHostnames = config.data_hostnames;
-			if (
-				dataHostnames && dataHostnames.length > 0
-				&& (dataUrlParsed.hostname === 'localhost' || (
-					!dataUrlParsed.hostname
-					&& window.location.hostname === 'localhost'
-				))
-			) {
-				dataUrlParsed.protocol = dataUrlParsed.protocol || window.location.protocol;
-				dataUrlParsed.hostname = dataHostnames[dataHostnamesRoundRobin];
-				dataUrlParsed.port = dataUrlParsed.port || window.location.port;
-				dataHostnamesRoundRobin++;
-				if (dataHostnamesRoundRobin >= dataHostnames.length) {
-					dataHostnamesRoundRobin = 0;
-				}
-				dataUrlFull = URL.format(dataUrlParsed);
-			}
+			dataUrlFull = backendApi.cycleHostname(dataUrlFull);
 			
 			persistentConnection.connect(dataUrlFull, queryParams);
 			

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -335,7 +335,7 @@ function init() {
 	}, {
 	});
 	
-	$(global).on('load resize orientationchange', _.throttle(function () {
+	$(global).on('resize orientationchange', _.throttle(function () {
 		dispatcher.emit('resize-window');
 	}, 50));
 	

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -89,9 +89,7 @@ function init() {
 				if (config.dashboard_template) {
 					// Parse the HTML template string into a DOM document.
 					var templateDocument = window.document.implementation.createHTMLDocument('');
-					templateDocument.open();
-					templateDocument.write(config.dashboard_template);
-					templateDocument.close();
+					templateDocument.documentElement.innerHTML = config.dashboard_template;
 					
 					// Prepare to move elements from the template to the current document.
 					var $src = $(templateDocument);

--- a/src/frontend/visualizers/image-visualizer.less
+++ b/src/frontend/visualizers/image-visualizer.less
@@ -12,6 +12,10 @@
 	
 	&__header {
 		padding: 10px 10px 6px;
+		
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 	
 	&__wrapper {

--- a/src/frontend/visualizers/plot-visualizer.js
+++ b/src/frontend/visualizers/plot-visualizer.js
@@ -60,14 +60,17 @@ _.extend(PlotVisualizer.prototype, {
 		
 		_this.$header.text( _this._options.header_text );
 		
+		// The series object is reused on plot updates, keeping the reference to the data.
+		_this._series = [
+			{
+				color: _this._options.color,
+				data: _this._data
+			}
+		];
+		
 		_this._flot = flot(
 			_this.$plot[0],
-			[
-				{
-					color: _this._options.color,
-					data: _this._data
-				}
-			],
+			_this._series,
 			{
 				series: {
 					lines: { show: true },
@@ -163,7 +166,7 @@ _.extend(PlotVisualizer.prototype, {
 			_this._flot.getOptions().xaxes[0].min = xMin;
 			_this._flot.getOptions().xaxes[0].max = xMax;
 			_this._flot.setupGrid();
-			_this._flot.setData([ plotData ]);
+			_this._flot.setData(_this._series);
 			_this._flot.draw();
 		}
 	},

--- a/src/frontend/visualizers/plot-visualizer.js
+++ b/src/frontend/visualizers/plot-visualizer.js
@@ -3,7 +3,10 @@
 var $ = require('jquery');
 var _ = require('underscore');
 
-var Rickshaw = require('rickshaw');
+var flot = require('flot');
+require('flot-plugin-resize');
+require('flot-plugin-time');
+
 var moment = require('moment');
 
 require('./plot-visualizer.less');
@@ -57,52 +60,40 @@ _.extend(PlotVisualizer.prototype, {
 		
 		_this.$header.text( _this._options.header_text );
 		
-		var graph = _this._graph = new Rickshaw.Graph({
-			element: _this.$plot[0],
-			width: _this.$plot.width(),
-			height: _this.$plot.height(),
-			renderer: _this._options.renderer,
-			preserve: true,
-			series: [
+		_this._flot = flot(
+			_this.$plot[0],
+			[
 				{
 					color: _this._options.color,
 					data: _this._data
 				}
 			],
-			min: _this._options.min,
-			max: _this._options.max,
-			interpolation: _this._options.interpolation
-		});
-		
-		var ticksTreatment = 'glow';
-		
-		var xAxisTimeUnit = _this._xAxisTimeUnit = {
-			seconds: _this._getTimeTickInterval(),
-			formatter: function (d) {
-				return moment(d).format(_this._options.tick_format);
+			{
+				series: {
+					lines: { show: true },
+					points: { show: true },
+					shadowSize: 0	// Drawing is faster without shadows
+				},
+				xaxis: {
+					mode: "time",
+					tickFormatter: function (d) {
+						return moment(d).format(_this._options.tick_format);
+					}
+				},
+				yaxis: {
+					min: _this._options.min,
+					max: _this._options.max
+				},
+				legend: {
+					show: true
+				}
 			}
-		};
+		);
 		
-		var xAxis = _this._xAxis = new Rickshaw.Graph.Axis.Time({
-			graph: graph,
-			ticksTreatment: ticksTreatment,
-			timeUnit: xAxisTimeUnit
-		});
-		
-		var yAxis = _this._yAxis = new Rickshaw.Graph.Axis.Y({
-			graph: graph,
-			tickFormat: Rickshaw.Fixtures.Number.formatKMBT,
-			ticksTreatment: ticksTreatment
-		});
-		
-		_this._updateSize();
 		_this._renderPlot();
 		_this._renderData();
 		
-		_this._layoutStore.on('layout-resized', _this._layoutResizedListener = function () {
-			_this._updateSize();
-			_this._renderPlot();
-		});
+		// The plot is resized automagically via CSS and the `flot-plugin-resize` module, no need for handling the `layout-resized` event and resizing manually.
 		
 		_this._dataStore.on('data-updated', _this._dataUpdatedListener = function (args) {
 			if (!args || !args.dataUrl || args.dataUrl === _this._dataUrl) {
@@ -114,48 +105,20 @@ _.extend(PlotVisualizer.prototype, {
 	componentWillUnmount: function () {
 		var _this = this;
 		
-		_this._layoutStore.removeListener('layout-resized', _this._layoutResizedListener);
-		_this._layoutResizedListener = null;
-		
 		_this._dataStore.removeListener('data-updated', _this._dataUpdatedListener);
 		_this._dataUpdatedListener = null;
 		
+		_this._flot.shutdown();
+		_this._flot = null;
+		
 		_this.$plot.empty();
 		_this.$header.empty();
-		
-		_this._graph = null;
-		_this._xAxis = null;
-		_this._xAxisTimeUnit = null;
-		_this._yAxis = null;
 	},
 	
 	_renderPlot: function () {
 		var _this = this;
 		
-		_this._renderTimeTicks();
-		
-		_this._graph.render();
-		_this._xAxis.render();
-		_this._yAxis.render();
-	},
-	
-	_updateSize: function () {
-		var _this = this;
-		
-		var $plotWrapper = _this.$plotWrapper;
-		var $plot = _this.$plot;
-		
-		$plot.hide();
-		
-		_this._plotWidth = $plotWrapper.width();
-		_this._plotHeight = $plotWrapper.height();
-		
-		_this._graph.configure({
-			width: _this._plotWidth,
-			height: _this._plotHeight
-		});
-		
-		$plot.show();
+		_this._flot.draw();
 	},
 	
 	_renderData: function () {
@@ -169,7 +132,8 @@ _.extend(PlotVisualizer.prototype, {
 			var selectedData = [],
 				ic = seriesData.length,
 				i = ic-1,
-				timeInterval = _this._options.time_interval;
+				timeInterval = _this._options.time_interval,
+				xMin, xMax;
 			
 			// Add new data:
 			while (i >= 0) {
@@ -189,61 +153,18 @@ _.extend(PlotVisualizer.prototype, {
 			
 			_this._stubData();
 			
-			// Convert to seconds (Rickshaw requires this time format):
-			plotData.forEach(function (point) {
-				point.x /= 1000;
+			// Convert to arrays (flot required this structure):
+			plotData.forEach(function (point, index) {
+				plotData[index] = [ point.x, point.y ];
+				if (point.x < xMin || xMin === undefined) { xMin = point.x; }
+				if (point.x > xMax || xMax === undefined) { xMax = point.x; }
 			});
 			
-			_this._renderTimeTicks();
-			
-			_this._graph.render();
-		}
-	},
-	
-	_getTimeTickInterval: function () {
-		var _this = this;
-		
-		var plotData = _this._data;
-		
-		var timeIntervalDefault = 10 * 1000;
-		
-		var timeInterval = (typeof _this._options.time_interval === 'number'
-			? _this._options.time_interval
-			: (plotData.length >= 2
-				? ((plotData[plotData.length-1].x - plotData[0].x) * 1000)
-				: timeIntervalDefault
-			)
-		);
-		
-		var tickCount = _this._options.tick_count;
-		
-		// HACK: If the space between ticks is too small, let there be one tick per plot.
-		var minWidthBetweenTicksInPixels = 70;
-		if (
-			_this._plotWidth > 0 &&
-			(_this._plotWidth / tickCount) < minWidthBetweenTicksInPixels
-		) {
-			tickCount = 1;
-		}
-		
-		var chartTickInterval = Math.ceil((timeInterval / 1000) / tickCount);
-		
-		return chartTickInterval;
-	},
-	
-	_renderTimeTicks: function () {
-		var _this = this,
-			chartTickInterval;
-		
-		if (_this._xAxisTimeUnit) {
-			chartTickInterval = _this._getTimeTickInterval();
-			if (chartTickInterval !== _this._xAxisTimeUnit.seconds) {
-				_this._xAxisTimeUnit.seconds = chartTickInterval;
-				
-				if (_this._xAxis) {
-					_this._xAxis.render();
-				}
-			}
+			_this._flot.getOptions().xaxes[0].min = xMin;
+			_this._flot.getOptions().xaxes[0].max = xMax;
+			_this._flot.setupGrid();
+			_this._flot.setData([ plotData ]);
+			_this._flot.draw();
 		}
 	},
 	

--- a/src/frontend/visualizers/plot-visualizer.less
+++ b/src/frontend/visualizers/plot-visualizer.less
@@ -12,17 +12,24 @@
 	
 	&__header {
 		padding: 10px 10px 6px;
+		
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 	
 	&__plot-wrapper {
 		.box-sizing(border-box);
 		
-		min-height: 100px;
-		
 		padding: 10px;
+		padding-top: 0;
 	}
 	
 	&__plot {
+		.box-sizing(border-box);
+		
+		height: 200px;
+		
 		overflow: hidden;
 		
 		background: rgba(0,150,255,0.1);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,9 +77,9 @@ var webpackConfig = {
 		alias: {
 			"jquery": path.join(__dirname, "node_modules/jquery/dist/" + (isProduction ? "jquery.min.js" : "jquery.js")),
 			
-			"flot": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.min.js" : "jquery.flot.js")),
-			"flot-plugin-resize": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.resize.min.js" : "jquery.flot.resize.js")),
-			"flot-plugin-time": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.time.min.js" : "jquery.flot.time.js")),
+			"flot": path.join(__dirname, "node_modules/Flot/" + ("jquery.flot.js")),
+			"flot-plugin-resize": path.join(__dirname, "node_modules/Flot/" + ("jquery.flot.resize.js")),
+			"flot-plugin-time": path.join(__dirname, "node_modules/Flot/" + ("jquery.flot.time.js")),
 			
 			"prefixer.less": path.join(__dirname, "src/frontend/vendor/prefixer.less"),
 			"flexbox.less": path.join(__dirname, "src/frontend/vendor/flexbox.less")
@@ -110,12 +110,7 @@ if (isProduction) {
 		}),
 		new webpack.optimize.DedupePlugin(),
 		new webpack.optimize.UglifyJsPlugin({
-			sourceMap: false,
-			mangle: {
-				except: [
-					"$super" //< "rickshaw" module uses "$super" for inheritance.
-				]
-			}
+			sourceMap: false
 		})
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,11 @@ var webpackConfig = {
 			"jquery",
 			"underscore",
 			"node-event-emitter",
-			"d3",
-			"rickshaw",
-			"rickshaw-css",
+			
+			"flot",
+			"flot-plugin-resize",
+			"flot-plugin-time",
+			
 			"moment"
 		]
 	},
@@ -37,20 +39,47 @@ var webpackConfig = {
 			}
 		],
 		loaders: [
-			{ test: /\.json$/i, loader: "json-loader" },
-			{ test: /\.less$/i, loader: "style-loader!css-loader!less-loader" },
-			{ test: /\.css$/i, loader: "style-loader!css-loader" },
-			{ test: /\.(jpe?g|png|gif)$/i, loader: "file-loader?name=[path][name].[ext]?[hash]" },
-			{ test: /\.(mp3|ac3|ogg|m4a)$/i, loader: "file-loader?name=[path][name].[ext]?[hash]" },
-			{ test: /\.(ttf|woff|eot)$/i, loader: "file-loader?name=[path][name].[ext]?[hash]" }
+			{
+				test: /jquery\.(\.min)?\.js$/,
+				loader: "exports-loader?jQuery.noConflict(true)"
+			},
+			{
+				test: /jquery\.flot(\.min)?\.js$/,
+				loader: "imports-loader?jQuery=jquery,this=>global!exports-loader?jQuery.plot"
+			},
+			{
+				test: /jquery\.flot(\.[a-z]+)(\.min)?\.js$/,
+				loader: "imports-loader?jQuery=jquery,this=>global!exports-loader?jQuery.plot"
+			},
+			{
+				test: /\.json$/i,
+				loader: "json-loader"
+			},
+			{
+				test: /\.less$/i,
+				loader: "style-loader!css-loader!less-loader"
+			},
+			{
+				test: /\.css$/i,
+				loader: "style-loader!css-loader"
+			},
+			{
+				test: /\.(jpe?g|png|gif)$/i,
+				loader: "file-loader?name=[path][name].[ext]?[hash]"
+			},
+			{
+				test: /\.(ttf|woff|eot)$/i,
+				loader: "file-loader?name=[path][name].[ext]?[hash]"
+			}
 		]
 	},
 	resolve: {
 		alias: {
 			"jquery": path.join(__dirname, "node_modules/jquery/dist/" + (isProduction ? "jquery.min.js" : "jquery.js")),
-			"d3": path.join(__dirname, "node_modules/d3/" + (isProduction ? "d3.min.js" : "d3.js")),
-			"rickshaw": path.join(__dirname, "node_modules/rickshaw/" + (isProduction ? "rickshaw.min.js" : "rickshaw.js")),
-			"rickshaw-css": path.join(__dirname, "node_modules/rickshaw/" + (isProduction ? "rickshaw.min.css" : "rickshaw.css")),
+			
+			"flot": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.min.js" : "jquery.flot.js")),
+			"flot-plugin-resize": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.resize.min.js" : "jquery.flot.resize.js")),
+			"flot-plugin-time": path.join(__dirname, "node_modules/Flot/" + (isProduction ? "jquery.flot.time.min.js" : "jquery.flot.time.js")),
 			
 			"prefixer.less": path.join(__dirname, "src/frontend/vendor/prefixer.less"),
 			"flexbox.less": path.join(__dirname, "src/frontend/vendor/flexbox.less")


### PR DESCRIPTION
* index: Added hostname cycling to layout and meta requests. Solved hitting connection limits on loading meta.
* index: Fixed dashboard template parsing. Solved empty view in Firefox.
* plot-visualizer: Replaced `Rickshaw` (SVG-based) with `Flot`
(canvas-based). Solved the freeze in Firefox, boosted performance in all browsers.
* plot-visualizer: Changed the default plot height to 200px.
* dashboard-layout: Fixed the layout flexibility on browser resize.